### PR TITLE
Removed stereotype of body type

### DIFF
--- a/src/sails.response.ts
+++ b/src/sails.response.ts
@@ -35,7 +35,7 @@ export class SailsResponse {
         return this.getBody().message;
     }
 
-    public getBody(): SailsIOClient.JWR.Body {
+    public getBody(): any {
         return this.JWR.body;
     }
 


### PR DESCRIPTION
The return type is fixed to a specific api implementation. Made it open for any sails backend.